### PR TITLE
chore(hacks): add ansible playbook for firewall connectivity testing

### DIFF
--- a/hacks/firewall-tests/ansible.cfg
+++ b/hacks/firewall-tests/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+inventory         = inventory.yml
+host_key_checking = False
+stdout_callback   = yaml

--- a/hacks/firewall-tests/group_vars/all.yml
+++ b/hacks/firewall-tests/group_vars/all.yml
@@ -1,0 +1,30 @@
+# IPs of probe VMs — fill these in after spinning up the VMs
+probes:
+  trusted:    "192.168.69.X"    # TODO
+  untrusted:  "192.168.42.X"    # TODO
+  guest:      "172.16.42.X"     # TODO
+  services:   "10.0.10.X"       # TODO
+  management: "10.0.0.X"        # TODO
+  storage:    "10.255.255.X"    # TODO
+
+# Exposed service IPs (matches firewall exposed-services address list).
+# These tests require the actual services to be running — if k8s or NAS is
+# down, the test fails even though the firewall rule is correct.
+exposed:
+  kubernetes_gw:
+    host: "10.0.10.250"
+    port: 443   # adjust to a port you know is open on your k8s cluster
+  nas_svc:
+    host: "10.0.10.245"
+    port: 443   # adjust to a known-open port on the NAS (e.g. 5000 for Synology DSM)
+
+# Reliable internet test target (Cloudflare DNS over HTTPS)
+internet:
+  host: "1.1.1.1"
+  port: 443
+
+# Port used for inter-probe tests (SSH on the probe VMs)
+probe_port: 22
+
+# How long nc waits before giving up — keep short since drop rules don't RST
+nc_timeout: 2

--- a/hacks/firewall-tests/group_vars/guest.yml
+++ b/hacks/firewall-tests/group_vars/guest.yml
@@ -1,0 +1,9 @@
+allowed_tests:
+  - { name: "guest -> internet", host: "{{ internet.host }}", port: "{{ internet.port }}" }
+
+blocked_tests:
+  - { name: "guest -> trusted probe",    host: "{{ probes.trusted }}",     port: "{{ probe_port }}" }
+  - { name: "guest -> untrusted probe",  host: "{{ probes.untrusted }}",   port: "{{ probe_port }}" }
+  - { name: "guest -> services probe",   host: "{{ probes.services }}",    port: "{{ probe_port }}" }
+  - { name: "guest -> management probe", host: "{{ probes.management }}",  port: "{{ probe_port }}" }
+  - { name: "guest -> storage probe",    host: "{{ probes.storage }}",     port: "{{ probe_port }}" }

--- a/hacks/firewall-tests/group_vars/management.yml
+++ b/hacks/firewall-tests/group_vars/management.yml
@@ -1,0 +1,11 @@
+allowed_tests:
+  - { name: "management -> internet",            host: "{{ internet.host }}",              port: "{{ internet.port }}" }
+  - { name: "management -> exposed k8s gateway", host: "{{ exposed.kubernetes_gw.host }}", port: "{{ exposed.kubernetes_gw.port }}" }
+  - { name: "management -> exposed NAS service", host: "{{ exposed.nas_svc.host }}",       port: "{{ exposed.nas_svc.port }}" }
+
+blocked_tests:
+  - { name: "management -> trusted probe",                   host: "{{ probes.trusted }}",    port: "{{ probe_port }}" }
+  - { name: "management -> untrusted probe",                 host: "{{ probes.untrusted }}",  port: "{{ probe_port }}" }
+  - { name: "management -> guest probe",                     host: "{{ probes.guest }}",      port: "{{ probe_port }}" }
+  - { name: "management -> storage probe",                   host: "{{ probes.storage }}",    port: "{{ probe_port }}" }
+  - { name: "management -> services probe (not in exposed)", host: "{{ probes.services }}",   port: "{{ probe_port }}" }

--- a/hacks/firewall-tests/group_vars/services.yml
+++ b/hacks/firewall-tests/group_vars/services.yml
@@ -1,0 +1,9 @@
+allowed_tests: []
+
+blocked_tests:
+  - { name: "services -> internet",          host: "{{ internet.host }}",     port: "{{ internet.port }}" }
+  - { name: "services -> trusted probe",     host: "{{ probes.trusted }}",    port: "{{ probe_port }}" }
+  - { name: "services -> untrusted probe",   host: "{{ probes.untrusted }}",  port: "{{ probe_port }}" }
+  - { name: "services -> guest probe",       host: "{{ probes.guest }}",      port: "{{ probe_port }}" }
+  - { name: "services -> management probe",  host: "{{ probes.management }}", port: "{{ probe_port }}" }
+  - { name: "services -> storage probe",     host: "{{ probes.storage }}",    port: "{{ probe_port }}" }

--- a/hacks/firewall-tests/group_vars/storage.yml
+++ b/hacks/firewall-tests/group_vars/storage.yml
@@ -1,0 +1,9 @@
+allowed_tests: []
+
+blocked_tests:
+  - { name: "storage -> internet",          host: "{{ internet.host }}",     port: "{{ internet.port }}" }
+  - { name: "storage -> trusted probe",     host: "{{ probes.trusted }}",    port: "{{ probe_port }}" }
+  - { name: "storage -> untrusted probe",   host: "{{ probes.untrusted }}",  port: "{{ probe_port }}" }
+  - { name: "storage -> guest probe",       host: "{{ probes.guest }}",      port: "{{ probe_port }}" }
+  - { name: "storage -> services probe",    host: "{{ probes.services }}",   port: "{{ probe_port }}" }
+  - { name: "storage -> management probe",  host: "{{ probes.management }}", port: "{{ probe_port }}" }

--- a/hacks/firewall-tests/group_vars/trusted.yml
+++ b/hacks/firewall-tests/group_vars/trusted.yml
@@ -1,0 +1,9 @@
+allowed_tests:
+  - { name: "trusted -> untrusted probe",   host: "{{ probes.untrusted }}",  port: "{{ probe_port }}" }
+  - { name: "trusted -> guest probe",       host: "{{ probes.guest }}",      port: "{{ probe_port }}" }
+  - { name: "trusted -> services probe",    host: "{{ probes.services }}",   port: "{{ probe_port }}" }
+  - { name: "trusted -> management probe",  host: "{{ probes.management }}", port: "{{ probe_port }}" }
+  - { name: "trusted -> storage probe",     host: "{{ probes.storage }}",    port: "{{ probe_port }}" }
+  - { name: "trusted -> internet",          host: "{{ internet.host }}",     port: "{{ internet.port }}" }
+
+blocked_tests: []

--- a/hacks/firewall-tests/group_vars/untrusted.yml
+++ b/hacks/firewall-tests/group_vars/untrusted.yml
@@ -1,0 +1,11 @@
+allowed_tests:
+  - { name: "untrusted -> internet",              host: "{{ internet.host }}",                    port: "{{ internet.port }}" }
+  - { name: "untrusted -> exposed k8s gateway",   host: "{{ exposed.kubernetes_gw.host }}",       port: "{{ exposed.kubernetes_gw.port }}" }
+  - { name: "untrusted -> exposed NAS service",   host: "{{ exposed.nas_svc.host }}",             port: "{{ exposed.nas_svc.port }}" }
+
+blocked_tests:
+  - { name: "untrusted -> trusted probe",                   host: "{{ probes.trusted }}",     port: "{{ probe_port }}" }
+  - { name: "untrusted -> guest probe",                     host: "{{ probes.guest }}",       port: "{{ probe_port }}" }
+  - { name: "untrusted -> management probe",                host: "{{ probes.management }}",  port: "{{ probe_port }}" }
+  - { name: "untrusted -> storage probe",                   host: "{{ probes.storage }}",     port: "{{ probe_port }}" }
+  - { name: "untrusted -> services probe (not in exposed)", host: "{{ probes.services }}",    port: "{{ probe_port }}" }

--- a/hacks/firewall-tests/inventory.yml
+++ b/hacks/firewall-tests/inventory.yml
@@ -1,0 +1,41 @@
+all:
+  vars:
+    ansible_user: debian
+    ansible_python_interpreter: /usr/bin/python3
+
+  children:
+    trusted:
+      hosts:
+        probe-trusted:
+          ansible_host: 192.168.69.X  # TODO: set after spinning up VM
+
+    untrusted:
+      hosts:
+        probe-untrusted:
+          ansible_host: 192.168.42.X  # TODO
+
+    guest:
+      hosts:
+        probe-guest:
+          ansible_host: 172.16.42.X   # TODO
+
+    services:
+      hosts:
+        probe-services:
+          # NOTE: DHCP has no gateway for this VLAN — set a static default route
+          # to 10.0.10.1 when provisioning this VM, otherwise return traffic breaks.
+          # Also pre-install netcat-openbsd since this VM cannot reach the internet.
+          ansible_host: 10.0.10.X     # TODO
+
+    management:
+      hosts:
+        probe-management:
+          ansible_host: 10.0.0.X      # TODO
+
+    storage:
+      hosts:
+        probe-storage:
+          # NOTE: DHCP has no gateway for this VLAN — set a static default route
+          # to 10.255.255.1 when provisioning this VM, otherwise return traffic breaks.
+          # Also pre-install netcat-openbsd since this VM cannot reach the internet.
+          ansible_host: 10.255.255.X  # TODO

--- a/hacks/firewall-tests/playbook.yml
+++ b/hacks/firewall-tests/playbook.yml
@@ -1,0 +1,55 @@
+---
+- name: Install test dependencies
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Install netcat-openbsd
+      ansible.builtin.apt:
+        name: netcat-openbsd
+        state: present
+        update_cache: false
+      # Services and Storage VMs have no internet access, so apt may fail.
+      # Pre-install netcat-openbsd on those VMs when provisioning.
+      ignore_errors: "{{ 'services' in group_names or 'storage' in group_names }}"
+
+- name: Firewall connectivity tests
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Run allowed connectivity checks
+      ansible.builtin.command: "nc -z -w {{ nc_timeout }} {{ item.host }} {{ item.port }}"
+      loop: "{{ allowed_tests | default([]) }}"
+      loop_control:
+        label: "{{ item.name }}"
+      changed_when: false
+      ignore_errors: true
+      register: allowed_results
+
+    - name: Assert allowed connections succeeded
+      ansible.builtin.assert:
+        that: item.rc == 0
+        fail_msg:    "FAIL [should be reachable]: {{ item.item.name }}"
+        success_msg: "PASS [reachable]:           {{ item.item.name }}"
+      loop: "{{ allowed_results.results | default([]) }}"
+      loop_control:
+        label: "{{ item.item.name }}"
+
+    - name: Run blocked connectivity checks
+      ansible.builtin.command: "nc -z -w {{ nc_timeout }} {{ item.host }} {{ item.port }}"
+      loop: "{{ blocked_tests | default([]) }}"
+      loop_control:
+        label: "{{ item.name }}"
+      changed_when: false
+      ignore_errors: true
+      register: blocked_results
+
+    - name: Assert blocked connections failed
+      ansible.builtin.assert:
+        that: item.rc != 0
+        fail_msg:    "FAIL [should be blocked]: {{ item.item.name }}"
+        success_msg: "PASS [blocked]:           {{ item.item.name }}"
+      loop: "{{ blocked_results.results | default([]) }}"
+      loop_control:
+        label: "{{ item.item.name }}"


### PR DESCRIPTION
Spins up probe VMs on each VLAN and uses `nc` to assert expected allow/block behaviour across all VLAN pairs.